### PR TITLE
Update package.json for missing babel v7 dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "build": "cross-env webpack --config ./webpack.config.prod.babel.js",
-    "postinstall": "npm install -g babel-cli@6.26.0 cross-env@5.0.5 webpack@3.6.0",
+    "postinstall": "npm install -g babel-cli@7.0.0-beta.3 cross-env@5.0.5 webpack@3.6.0",
     "start": "npm run start-prod",
     "start-dev": "cross-env NODE_ENV=development babel-node server --useServerRender=true --useLiveData=false",
     "start-prod": "npm run build && cross-env NODE_ENV=production babel-node server --useServerRender=true --useLiveData=false"
@@ -16,6 +16,7 @@
   "dependencies": {
     "@babel/cli": "^7.0.0",
     "@babel/core": "^7.0.0",
+    "@babel/node": "^7.2.2",
     "@babel/plugin-proposal-object-rest-spread": "^7.0.0",
     "@babel/plugin-transform-regenerator": "^7.0.0",
     "@babel/preset-env": "^7.0.0",


### PR DESCRIPTION
To resolve issue #12 Error: Requires Babel "^7.0.0-0", but was loaded with "6.26.3".