### PR TITLE
'delay' is a named export and should be imported as '{ delay }'

### DIFF
--- a/src/components/__tests__/NotificationsViewer.js
+++ b/src/components/__tests__/NotificationsViewer.js
@@ -1,7 +1,7 @@
 import NotificationsViewer from '../NotificationsViewer';
 import renderer from 'react-test-renderer';
 import React from 'react';
-import delay from 'redux-saga';
+import { delay } from 'redux-saga';
 
 jest.mock('../../services/NotificationsService');
 


### PR DESCRIPTION
The 'NotificationsViewer' test was not running. After a short investigation I found that 'delay' should be imported as '{ delay }' is it is a named export from 'redux-saga'