### PR TITLE
added jest testURL to package.json, was receiving error from original

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,10 @@
     "start-prod": "npm run build && cross-env NODE_ENV=production babel-node server --useServerRender=true --useLiveData=false",
     "test": "jest"
   },
+  "jest": {
+    "verbose": true,
+    "testURL": "http://localhost"
+  },
   "keywords": [],
   "author": "Daniel Stern (Code Whisperer)",
   "license": "MIT",


### PR DESCRIPTION
was receiving the error "SecurityError: localStorage is not available for opaque origins at Window.get localStorage [as localStorage] (node_modules/jsdom/lib/jsdom/browser/Window.j
s:257:15") when trying to run command 'npm run test'

found fix here: https://github.com/facebook/jest/issues/6766#issuecomment-408344243
