### PR TITLE
Fix: import correct delay function

### DIFF
--- a/src/App.spec.js
+++ b/src/App.spec.js
@@ -1,4 +1,4 @@
-import delay from 'redux-saga';
+import { delay } from 'redux-saga';
 
 it("async test 1",done=>{
     setTimeout(done,100);


### PR DESCRIPTION
You forgot to use named import for delay function. redux-saga default exports the `createSagaMiddleware` function.

By the way, I loved your react testing course at pluralsight! Thanks!